### PR TITLE
Update shared_strings.dart

### DIFF
--- a/lib/src/sharedStrings/shared_strings.dart
+++ b/lib/src/sharedStrings/shared_strings.dart
@@ -23,6 +23,8 @@ class _SharedStringsMaintainer {
       _list.add(val);
       _index += 1;
     } else {
+      _list.add(val);
+      _index+=1;
       _map[val].increaseCount();
     }
   }


### PR DESCRIPTION
 !!!same shared string key make xml parsing in a wrong way.
  
 for MS office excel 2019 which take shared string as list but not map, same shared string should be all kept at list structure, but keep map as before.
 
 for WPS(software like excel), same shared string is taken as MAP,no need to change anything